### PR TITLE
Use XString instead of B for perlstring calls.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -51,6 +51,7 @@ my %META = (
 
 my %MM_ARGS = (
   PREREQ_PM => {
+    'XString' => '0.005',
     ("$]" >= 5.008_000 ? () : ('Task::Weaken' => 0)),
   },
 );

--- a/lib/Sub/Quote.pm
+++ b/lib/Sub/Quote.pm
@@ -10,11 +10,10 @@ use Scalar::Util qw(weaken);
 use Exporter qw(import);
 use Carp qw(croak);
 BEGIN { our @CARP_NOT = qw(Sub::Defer) }
-use B ();
+
+use XString ();
 BEGIN {
   *_HAVE_IS_UTF8 = defined &utf8::is_utf8 ? sub(){1} : sub(){0};
-  *_HAVE_PERLSTRING = defined &B::perlstring ? sub(){1} : sub(){0};
-  *_BAD_BACKSLASH_ESCAPE = _HAVE_PERLSTRING() && "$]" == 5.010_000 ? sub(){1} : sub(){0};
   *_HAVE_HEX_FLOAT = !$ENV{SUB_QUOTE_NO_HEX_FLOAT} && "$]" >= 5.022 ? sub(){1} : sub(){0};
 
   # This may not be perfect, as we can't tell the format purely from the size
@@ -46,19 +45,6 @@ our @EXPORT_OK = qw(quotify capture_unroll inlinify sanitize_identifier);
 our %QUOTED;
 
 my %escape;
-if (_BAD_BACKSLASH_ESCAPE) {
-  %escape = (
-    (map +(chr($_) => sprintf '\x%02x', $_), 0 .. 0x31, 0x7f),
-    "\t" => "\\t",
-    "\n" => "\\n",
-    "\r" => "\\r",
-    "\f" => "\\f",
-    "\b" => "\\b",
-    "\a" => "\\a",
-    "\e" => "\\e",
-    (map +($_ => "\\$_"), qw(" \ $ @)),
-  );
-}
 
 sub quotify {
   my $value = $_[0];
@@ -116,14 +102,8 @@ sub quotify {
     }
   )
   : !length($value) && length( (my $dummy2 = '') & $value ) ? '(!1)' # false
-  : _BAD_BACKSLASH_ESCAPE && _HAVE_IS_UTF8 && utf8::is_utf8($value) ? do {
-    $value =~ s/(["\$\@\\[:cntrl:]]|[^\x00-\x7f])/
-      $escape{$1} || sprintf('\x{%x}', ord($1))
-    /ge;
-    qq["$value"];
-  }
-  : _HAVE_PERLSTRING ? B::perlstring($value)
-  : qq["\Q$value\E"];
+  : XString::perlstring($value)
+  ;
 }
 
 sub sanitize_identifier {

--- a/t/quotify-5.6.t
+++ b/t/quotify-5.6.t
@@ -4,9 +4,8 @@ no warnings 'once';
 use B;
 BEGIN {
   local $utf8::{is_utf8};
-  local $B::{perlstring};
   require Sub::Quote;
 }
 die "Unable to disable utf8::is_utf8 and B::perlstring for testing"
-  unless !Sub::Quote::_HAVE_IS_UTF8 && ! Sub::Quote::_HAVE_PERLSTRING;
+  unless !Sub::Quote::_HAVE_IS_UTF8;
 do './t/quotify.t' or die $@ || $!;


### PR DESCRIPTION
XString provides perlstring and cstring functions from B without the
overhead and is backward compatible for perl versions.

Reduces Moo memory overhead as it doesn't have to load B