### PR TITLE
fix new qw warning in perl 5.43.3

### DIFF
--- a/lib/Sub/Quote.pm
+++ b/lib/Sub/Quote.pm
@@ -61,7 +61,7 @@ BEGIN {
       "\b" => "\\b",
       "\a" => "\\a",
       "\e" => "\\e",
-      (map +($_ => "\\$_"), qw(" \ $ @)),
+      (map +($_ => "\\$_"), qw(" \\ $ @)),
     );
     *_perlstring = sub {
       my $value = shift;


### PR DESCRIPTION
Recent blead perls have started emitting the following warning:

    Possible attempt to escape whitespace in qw() list at /home/cpan/bin/perl/lib/site_perl/5.43.2/Sub/Quote.pm line 64.

This breaks some downstream modules that don't expect any warnings from Sub::Quote.