### PR TITLE
fix "hintshash" documentation

### DIFF
--- a/lib/Sub/Quote.pm
+++ b/lib/Sub/Quote.pm
@@ -501,7 +501,7 @@ The value of L<< C<${^WARNING_BITS}> | perlvar/${^WARNING_BITS} >> to use for
 the code being evaluated.  This captures the L<warnings> set.  If not specified,
 the warnings from the calling code will be used.
 
-=item C<%^H>
+=item C<hintshash>
 
 The value of L<< C<%^H> | perlvar/%^H >> to use for the code being evaluated.
 This captures additional pragma settings.  If not specified, the value from the


### PR DESCRIPTION
The name of the option to set %^H in the generated code is "hintshash", not "%^H".

Fixes RT#147392.