### PR TITLE
fix author tests on perl 5.42

### DIFF
--- a/t/quotify.t
+++ b/t/quotify.t
@@ -38,6 +38,9 @@ BEGIN {
     ;
 
     $v and
+      # Scalar::Util breaks on 5.42 if its Perl/XS parts see inconsistent perl
+      # versions, so load it now before it gets pulled in by Test::More below
+      (require Scalar::Util),
       ($v = sprintf "%.6f", $v),
       (my $t = $v + 0),
       (Internals::SvREADONLY($], 0)),


### PR DESCRIPTION
Starting with perl 5.42, xt/quotify-5.10.0.t and xt/quotify-5.6.t have started failing:

    Undefined subroutine &Scalar::Util::reftype called at /home/cpan/lib/5.42.0/Test2/API/Instance.pm line 285.
    Compilation failed in require at /home/cpan/lib/5.42.0/Test/Builder/Module.pm line 5.
    BEGIN failed--compilation aborted at /home/cpan/lib/5.42.0/Test/Builder/Module.pm line 5.
    Compilation failed in require at /home/cpan/lib/5.42.0/Test/More.pm line 22.
    BEGIN failed--compilation aborted at /home/cpan/lib/5.42.0/Test/More.pm line 22.
    Compilation failed in require at ./t/quotify.t line 58.
    BEGIN failed--compilation aborted at ./t/quotify.t line 58.

This is because these tests artificially reset $] to 5.010/5.006, which makes Scalar::Util believe builtin::reftype doesn't exist yet, which is what it would normally use. But the XS portion of Scalar::Util checks PERL_VERSION directly, so it doesn't define XS replacements for functions like reftype because the actual perl executable is deemed recent enough.

Work around the issue by loading Scalar::Util before messing with $].